### PR TITLE
Fix: g++: error: unrecognized option '-h'

### DIFF
--- a/ext/jasmine-webkit-specrunner/extconf.rb
+++ b/ext/jasmine-webkit-specrunner/extconf.rb
@@ -1,2 +1,8 @@
-system %{qmake -spec macx-g++}
+case RUBY_PLATFORM
+when /linux/
+	system %{qmake -spec linux-g++}
+else
+	system %{qmake -spec macx-g++}
+end
+
 system %{make}


### PR DESCRIPTION
Compiling on Arch Linux, and maybe on other Linux systems, fails because of using a macx spec even on Linux systems.
