### PR TITLE
Jasmine 1.1 compatibility

### DIFF
--- a/jasmine-headless-webkit.gemspec
+++ b/jasmine-headless-webkit.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'jasmine'
+  s.add_dependency 'jasmine', '~>1.1.beta'
   s.add_dependency 'coffee-script', '>= 2.2'
   s.add_dependency 'rainbow'
 end

--- a/lib/jasmine/files_list.rb
+++ b/lib/jasmine/files_list.rb
@@ -14,8 +14,8 @@ module Jasmine
     attr_reader :files, :filtered_files, :spec_outside_scope
 
     DEFAULT_FILES = [
-      File.join(Jasmine.root, "lib/jasmine.js"),
-      File.join(Jasmine.root, "lib/jasmine-html.js"),
+      File.join(Jasmine::Core.path, "jasmine.js"),
+      File.join(Jasmine::Core.path, "jasmine-html.js"),
       File.expand_path('../../../jasmine/jasmine.headless-reporter.js', __FILE__)
     ]
 

--- a/spec/lib/jasmine/files_list_spec.rb
+++ b/spec/lib/jasmine/files_list_spec.rb
@@ -9,8 +9,8 @@ describe Jasmine::FilesList do
   describe '#initialize' do
     it "should have default files" do
       files_list.files.should == [
-        File.join(Jasmine.root, "lib/jasmine.js"),
-        File.join(Jasmine.root, "lib/jasmine-html.js"),
+        File.join(Jasmine::Core.path, "jasmine.js"),
+        File.join(Jasmine::Core.path, "jasmine-html.js"),
         File.expand_path('jasmine/jasmine.headless-reporter.js')
       ]
     end


### PR DESCRIPTION
This changes Jasmine.root to Jasmine::Core.path to work with jasmine 1.1 (beta)
