### PR TITLE
-c/--no-colors are broken.

### DIFF
--- a/ext/jasmine-webkit-specrunner/specrunner.cpp
+++ b/ext/jasmine-webkit-specrunner/specrunner.cpp
@@ -381,7 +381,7 @@ int main(int argc, char** argv)
 
     QApplication app(argc, argv);
     HeadlessSpecRunner runner;
-    runner.setColors(true);
+    runner.setColors(showColors);
     runner.reportFile(reporter);
 
     for (index = optind; index < argc; index++) {


### PR DESCRIPTION
Hi John,

The documentation says that the showColors option defaults to false and that you can override it with -c. This brings the code into line with that.

Conrad
