### PR TITLE
require yaml in runner.rb

### DIFF
--- a/lib/jasmine/headless/runner.rb
+++ b/lib/jasmine/headless/runner.rb
@@ -9,6 +9,8 @@ require 'rainbow'
 require 'jasmine/files_list'
 require 'jasmine/template_writer'
 
+require 'yaml'
+
 module Jasmine
   module Headless
     class Runner


### PR DESCRIPTION
fixes bad YAML module look-up that would give the following error:

[jasmine-headless-webkit] uninitialized constant Jasmine::Headless::Runner::YAML (NameError)
/gems/jasmine-headless-webkit-0.6.0/lib/jasmine/headless/runner.rb:47:in `jasmine_config'
