### PR TITLE
Fix for issue #43: unitialized constant during `rake` for Rails 2.3 applications

### DIFF
--- a/lib/jasmine-headless-webkit.rb
+++ b/lib/jasmine-headless-webkit.rb
@@ -5,5 +5,5 @@ module Jasmine
   end
 end
 
-require 'jasmine/headless/railtie' if defined?(Rails)
+require 'jasmine/headless/railtie' if defined?(Rails) && Rails::VERSION::MAJOR >= 3
 


### PR DESCRIPTION
This makes issue #43 (which I just opened) go away by simply not loading the railtie when the detected Rails version is not 3.0 or greater.
