### PR TITLE
Patch to allow running specs containing UTF-8

### DIFF
--- a/lib/jasmine/template_writer.rb
+++ b/lib/jasmine/template_writer.rb
@@ -24,6 +24,7 @@ module Jasmine
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
+  <meta content="text/html;charset=UTF-8" http-equiv="Content-Type"/>
   <title>Jasmine Test Runner</title>
   <script type="text/javascript">
     window.console = { log: function(data) { 


### PR DESCRIPTION
Hi, I added this patch to allow running specs whose source files contain UTF-8-encoded characters.  We found these specs would pass when run via a normal browser and the regular Jasmine spec server, but would fail under jasmine-headless-webkit because the headless browser was loading the source files as latin1.

The fix is to set the character encoding of the autogenerated HTML test harness to UTF-8, which causes the headless browser to assume all the loaded source files are also UTF-8.  (This is the same approach as taken by the spec server.)
## Cheers,

Sam Stokes
Rapportive
