### PR TITLE
Fix global defaults file path

### DIFF
--- a/lib/jasmine/headless.rb
+++ b/lib/jasmine/headless.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 module Jasmine::Headless
   autoload :CoffeeScriptCache, 'jasmine/headless/coffee_script_cache'
   autoload :SpecFileAnalyzer, 'jasmine/headless/spec_file_analyzer'

--- a/lib/jasmine/headless/options.rb
+++ b/lib/jasmine/headless/options.rb
@@ -21,7 +21,7 @@ module Jasmine
       }
 
       DEFAULTS_FILE = File.join(Dir.pwd, '.jasmine-headless-webkit')
-      GLOBAL_DEFAULTS_FILE = File.expand_path("~/#{DEFAULTS_FILE}")
+      GLOBAL_DEFAULTS_FILE = File.expand_path('~/.jasmine-headless-webkit')
 
       def self.from_command_line
         options = new


### PR DESCRIPTION
In lib/jasmine/headless/options.rb, GLOBAL_DEFAULTS_FILE was defined with Dir.pwd in the path. It should just be ~/.jasmine-headless-webkit.
