### PR TITLE
Parse and run ERB tags inside YAML config

### DIFF
--- a/lib/jasmine/headless/runner.rb
+++ b/lib/jasmine/headless/runner.rb
@@ -4,6 +4,7 @@ require 'coffee-script'
 require 'rainbow'
 
 require 'yaml'
+require 'erb'
 require 'sprockets'
 
 
@@ -112,7 +113,7 @@ module Jasmine
       def jasmine_config_data
         raise JasmineConfigNotFound.new("Jasmine config not found. I tried #{@options[:jasmine_config]}.") if !File.file?(@options[:jasmine_config])
 
-        YAML.load_file(@options[:jasmine_config])
+        YAML.load(ERB.new(File.read(@options[:jasmine_config])).result(binding))
       end
     end
   end

--- a/spec/lib/jasmine/headless/runner_spec.rb
+++ b/spec/lib/jasmine/headless/runner_spec.rb
@@ -37,12 +37,16 @@ describe Jasmine::Headless::Runner do
     context 'file exists' do
       before do
         File.open(Jasmine::Headless::Runner::RUNNER, 'w')
-        File.open(config_filename, 'w') { |fh| fh.print YAML.dump('test' => 'hello') }
+        File.open(config_filename, 'w') { |fh| fh.print YAML.dump('test' => 'hello', 'erb' => '<%= "erb" %>') }
       end
 
       it 'should load the jasmine config' do
         runner.jasmine_config['test'].should == 'hello'
         runner.jasmine_config['spec_dir'].should == 'spec/javascripts'
+      end
+
+      it 'should execute ERB in the config file' do
+        runner.jasmine_config['erb'].should == 'erb'
       end
     end
 


### PR DESCRIPTION
Jasmine gem allows ERB inside jasmine.yaml, but jasmine-headless-webkit doesn't do anything to these tags. This patch runs the config file via ERB before passing it to YAML for deserialization.
