### PR TITLE
Ability to register custom template engines...

### DIFF
--- a/lib/jasmine/headless/files_list.rb
+++ b/lib/jasmine/headless/files_list.rb
@@ -38,6 +38,7 @@ module Jasmine::Headless
 
       def reset!
         @asset_paths = nil
+        @registered_engines = {}
 
         # register haml-sprockets and handlebars_assets if it's available...
         %w{haml-sprockets handlebars_assets}.each do |library|
@@ -67,6 +68,21 @@ module Jasmine::Headless
           register_engine '.css', Jasmine::Headless::CSSTemplate
           register_engine '.jst', Jasmine::Headless::JSTTemplate
         end
+
+      end
+
+      def registered_engines
+        @registered_engines ||= {}
+      end
+
+      def register_engine(file_extension, template_class)
+        registered_engines[file_extension] = template_class
+      end
+
+      def register_engines!
+        registered_engines.each do |file_extension, template_class|
+          Sprockets.register_engine file_extension, template_class
+        end
       end
 
       def default_files
@@ -95,9 +111,19 @@ module Jasmine::Headless
       @required_files = UniqueAssetList.new
       @potential_files_to_filter = []
 
+      register_engines!
+
       load_initial_assets
 
       use_config if config?
+    end
+
+    def register_engines!
+      begin
+        require spec_helper
+      rescue LoadError
+      end
+      self.class.register_engines!
     end
 
     def load_initial_assets
@@ -301,5 +327,17 @@ module Jasmine::Headless
         end
       end
     end
+
+    def spec_helper
+      File.join(spec_dir, "helpers", "spec_helper")
+    end
+  end
+end
+
+module Jasmine::Headless
+  extend self
+
+  def register_engine(file_extension, template_class)
+    Jasmine::Headless::FilesList.register_engine(file_extension, template_class)
   end
 end

--- a/spec/lib/jasmine/headless/files_list_spec.rb
+++ b/spec/lib/jasmine/headless/files_list_spec.rb
@@ -218,6 +218,21 @@ describe Jasmine::Headless::FilesList do
         files_list.files.any? { |file| file['.erb'] }.should be_false
       end
     end
+
+    describe "#register_engine!" do
+
+      before(:each) do
+        Jasmine::Headless::FilesList.reset!
+      end
+
+      it "should register code added via configure blocks" do
+        template_class = mock()
+        described_class.register_engine ".foo", template_class
+        Sprockets.expects(:register_engine).with(".foo", template_class)
+        described_class.new
+      end
+
+    end
   end
 end
 


### PR DESCRIPTION
...via Jasmine::Headless.register_engine hook

In response to [issue #102](https://github.com/johnbintz/jasmine-headless-webkit/issues/102), I added the ability to register custom template engines not currently supported by default in JHW. The hook may be registered by placing ruby code in #{spec_dir}/helpers/spec_helper.rb. (Perhaps the location of this file can be configurable.)

For example, I am using the following to compile Handlebars templates via the `handlebars_assets` gem for JHW in my current project:

``` ruby
# spec/javascripts/helpers/spec_helper.rb

require 'sprockets'
require 'handlebars_assets'

module Jasmine::Headless
  class HandlebarsTemplate < HandlebarsAssets::TiltHandlebars
    include Jasmine::Headless::FileChecker
    def evaluate(*args)
      if bad_format?(file)
        alert_bad_format(file)
        return ''
      end
      %{<script type="text/javascript">#{super}</script>}
    end
  end
end

Jasmine::Headless.register_engine '.hbs', Jasmine::Headless::HandlebarsTemplate
```
