### PR TITLE
Add a minimum required rubygems version to the gemspec

### DIFF
--- a/jasmine-headless-webkit.gemspec
+++ b/jasmine-headless-webkit.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+  s.required_rubygems_version = ">= 1.8.0"
 
   s.add_runtime_dependency 'jasmine-core', '~> 1.1'
   s.add_runtime_dependency 'coffee-script'

--- a/lib/jasmine/headless/files_list.rb
+++ b/lib/jasmine/headless/files_list.rb
@@ -4,6 +4,7 @@ require 'multi_json'
 require 'set'
 require 'sprockets'
 require 'sprockets/engines'
+require 'rubygems'
 
 module Jasmine::Headless
   class FilesList
@@ -12,10 +13,6 @@ module Jasmine::Headless
     class << self
       def asset_paths
         return @asset_paths if @asset_paths
-
-        require 'rubygems'
-
-        raise StandardError.new("A newer version of Rubygems is required to use vendored assets. Please upgrade.") if !Gem::Specification.respond_to?(:each)
 
         @asset_paths = []
 


### PR DESCRIPTION
Adds a minimum rubygems version to check the dependency at installation time instead of runtime. 1.8.0 is the version that adds Gem::Specification#each, so that's what I set the minimum to.
