### PR TITLE
Compile .coffee.erb files as regular .coffee files.

### DIFF
--- a/lib/jasmine/headless.rb
+++ b/lib/jasmine/headless.rb
@@ -3,7 +3,7 @@ require 'pathname'
 module Jasmine
   module Headless
     
-    EXCLUDED_FORMATS = %w{less sass scss erb str}
+    EXCLUDED_FORMATS = %w{less sass scss str}
     
     autoload :CommandLine, 'jasmine/headless/command_line'
 
@@ -23,6 +23,7 @@ module Jasmine
     autoload :FileChecker, 'jasmine/headless/file_checker'
 
     autoload :CoffeeTemplate, 'jasmine/headless/coffee_template'
+    autoload :CoffeeErbTemplate, 'jasmine/headless/coffee_erb_template'
     autoload :JSTemplate, 'jasmine/headless/js_template'
     autoload :JSTTemplate, 'jasmine/headless/jst_template'
     autoload :CSSTemplate, 'jasmine/headless/css_template'

--- a/lib/jasmine/headless/coffee_erb_template.rb
+++ b/lib/jasmine/headless/coffee_erb_template.rb
@@ -1,0 +1,20 @@
+require 'tilt/template'
+require 'rainbow'
+
+module Jasmine::Headless
+  # This template flattens .coffee.erb files that may be present on
+  # the Rails asset pipeline. The file is rendered as CoffeeScript;
+  # erb template will not be rendered. 
+  class CoffeeErbTemplate < Tilt::Template
+
+    def prepare ; end
+
+    def evaluate(scope, locals, &block)
+      if file[/coffee.erb$/]
+        Jasmine::Headless.warn("[%s] %s: %s" % [ "Erb File".color(:magenta), file.color(:yellow), "flatten template".color(:white) ])
+      end
+      return ''
+    end
+  end
+end
+

--- a/lib/jasmine/headless/files_list.rb
+++ b/lib/jasmine/headless/files_list.rb
@@ -45,6 +45,7 @@ module Jasmine::Headless
           register_engine '.js', Jasmine::Headless::JSTemplate
           register_engine '.css', Jasmine::Headless::CSSTemplate
           register_engine '.jst', Jasmine::Headless::JSTTemplate
+          register_engine '.erb', Jasmine::Headless::CoffeeErbTemplate
         end
       end
 


### PR DESCRIPTION
Rails pipeline offers a way to compile a file through multiple targets.
A coffeescript source file may be first compiled through erb renderer.
Example of an use case would be to compile constants such as API keys into JS.

This makes possible to test the functional parts of the source code that is
unaffected by the values inserted by erb compiler.
