### PR TITLE
Fixed getLastModified callback firing three times 

### DIFF
--- a/skel/template.html.erb
+++ b/skel/template.html.erb
@@ -44,9 +44,11 @@
             http.open('HEAD', location, true);
 
             http.onreadystatechange = function() {
-              console.log(http);
-              console.log(http.getResponseHeader('Last-Modified'));
-              callback(http.getResponseHeader('Last-Modified'));
+              if(http.readyState === http.DONE) {
+                console.log(http);
+                console.log(http.getResponseHeader('Last-Modified'));
+                callback(http.getResponseHeader('Last-Modified'));
+              }
             };
             http.send();
           }


### PR DESCRIPTION
getLastModified()'s callback was firing every time the readyState changes, three times for every request. 
