### PR TITLE
Sort order in directory globs

### DIFF
--- a/lib/jasmine/headless/files_list.rb
+++ b/lib/jasmine/headless/files_list.rb
@@ -255,7 +255,8 @@ module Jasmine::Headless
     end
 
     def expanded_dir(path)
-      Dir[path].find_all { |file|
+      file_list = Dir.glob(path).sort
+      file_list.find_all { |file|
         file[extension_filter] && !alert_if_bad_format?(file)
       }.collect {
         |file| File.expand_path(file)


### PR DESCRIPTION
Hello,

The order in which Jasmine headless webkit loads files specified on jasmine.yml is file system dependent.
On MacOS X, HFS+ guarantees that directory entries are read in sorted order (http://developer.apple.com/legacy/mac/library/#technotes/tn/tn1150.html).  This is not the case with other Unix filesystems such as ext2/ext3/ext4 under Linux.  The inconsistency in load order results in a test suite that works in one place (e.g. on a Mac) but the same suite fails due to load order problems in another (e.g. on a Linux box).  In fact, the results can differ from one copy of a suite to another on the same Linux box depending on the sequence of file create, remove, etc. calls in each copy. A simple solution is to sort the results of expanding a directory glob so that the results are consistent across platforms.
