### PR TITLE
Allow non-true options to override defaults

### DIFF
--- a/lib/jasmine/headless/options.rb
+++ b/lib/jasmine/headless/options.rb
@@ -41,7 +41,7 @@ module Jasmine
         @options[:seed] = rand(10000)
         read_defaults_files
 
-        opts.each { |k, v| @options[k] = v if v }
+        opts.each { |k, v| @options[k] = v }
       end
 
       def process_option(*args)


### PR DESCRIPTION
I would like to be able to put this:

```
guard 'jasmine-headless-webkit', :full_run => false, :all_on_start => false do
```

in my guard file and not have it run the full set of tests. Since it doesn't use the command line it passes through `opts.each { |k, v| @options[k] = v if v }`. Unfortunately this line prevents my `:full_run` option from being used as it's value is false, so it doesn't override the default true value.

I think this is the proper fix but I'm not exactly sure why the `if v` was there in the first place. 
