### PR TITLE
Exposed sprockets_environment from Jasmine::Headless

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'mocha'
 
 gem 'cucumber'
 
-gem 'jquery-rails', '~> 1.0.0'
+gem 'jquery-rails', '> 1.0'
 gem 'ejs'
 
 gem 'guard-jasmine-headless-webkit', :git => 'git://github.com/johnbintz/guard-jasmine-headless-webkit.git'

--- a/lib/jasmine/headless/file_checker.rb
+++ b/lib/jasmine/headless/file_checker.rb
@@ -1,3 +1,5 @@
+require 'rainbow'
+
 module Jasmine::Headless::FileChecker
   def excluded_formats
     ::Jasmine::Headless::EXCLUDED_FORMATS

--- a/lib/jasmine/headless/files_list.rb
+++ b/lib/jasmine/headless/files_list.rb
@@ -39,6 +39,10 @@ module Jasmine::Headless
         @sprockets_environment = nil
       end
 
+      def sprockets_environment
+        @sprockets_environment ||= Sprockets::Environment.new
+      end
+
       def registered_engines
         @registered_engines ||= {}
       end
@@ -138,7 +142,7 @@ module Jasmine::Headless
     def sprockets_environment
       return @sprockets_environment if @sprockets_environment
 
-      @sprockets_environment = Sprockets::Environment.new
+      @sprockets_environment = self.class.sprockets_environment #|| Sprockets::Environment.new
       search_paths.each { |path| @sprockets_environment.append_path(path) }
 
       @sprockets_environment.unregister_postprocessor('application/javascript', Sprockets::SafetyColons)
@@ -325,6 +329,10 @@ end
 
 module Jasmine::Headless
   extend self
+
+  def sprockets_environment
+    Jasmine::Headless::FilesList.sprockets_environment
+  end
 
   def register_engine(file_extension, template_class)
     Jasmine::Headless::FilesList.register_engine(file_extension, template_class)

--- a/spec/lib/jasmine/headless/files_list_spec.rb
+++ b/spec/lib/jasmine/headless/files_list_spec.rb
@@ -189,6 +189,20 @@ describe Jasmine::Headless::FilesList do
       end
 
     end
+
+    describe "#sprockets_environment" do
+
+      before(:each) do
+        Jasmine::Headless::FilesList.reset!
+      end
+
+      it "should return shared class-level sprockets environment that will be used when tests are run" do
+        processor = Object.new
+        described_class.sprockets_environment.register_postprocessor "application/javascript", processor
+        described_class.new.sprockets_environment.postprocessors["application/javascript"].should include(processor)
+      end
+
+    end
   end
 end
 


### PR DESCRIPTION
- Allows for manipulation of the Sprockets::Environment for things like adding/removing pre/postprocessors from within spec_helper.rb (more flexibility than just registering engines).
- Also, fixed specs that were failing on files_list.rb whenrun standalone due to missing require in file_checker.rb
