### PR TITLE
Fix coffeescript compilation error in spec.coffee

### DIFF
--- a/spec/jasmine/coffeescript_error/spec.coffee
+++ b/spec/jasmine/coffeescript_error/spec.coffee
@@ -1,2 +1,3 @@
-if
+if (->)
+  noOp = "complete"
 


### PR DESCRIPTION
2.2.0 has a much more sophisticated parser. Empty ifs are no longer
valid syntax. Use a no-op function to demonstrate validate coffeescript
parsing.
