### PR TITLE
Add application/javascript content_type to jst compiler.

### DIFF
--- a/lib/jasmine/headless/jst_template.rb
+++ b/lib/jasmine/headless/jst_template.rb
@@ -3,6 +3,9 @@ require 'sprockets/jst_processor'
 module Jasmine::Headless
   class JSTTemplate < Sprockets::JstProcessor
     include Jasmine::Headless::FileChecker
+
+    self.default_mime_type = 'application/javascript'
+
     def evaluate(*args)
       if bad_format?(file)
         alert_bad_format(file)


### PR DESCRIPTION
Hi,

While testing this gem with `.jst.eco` templates, they wouldn't render unless this was added to the JST compiler wrapper. 

Otherwise, `mime_type` for `.jst.eco` files is detected as `application/octet-stream`.
