### PR TITLE
Qt 4.8 fix

### DIFF
--- a/ext/jasmine-webkit-specrunner/specrunner.cpp
+++ b/ext/jasmine-webkit-specrunner/specrunner.cpp
@@ -23,6 +23,10 @@
 
 #include "Runner.h"
 
+#if QT_VERSION >= QT_VERSION_CHECK(4, 8, 0)
+#include <getopt.h>
+#endif
+
 #if QT_VERSION < QT_VERSION_CHECK(4, 7, 0)
 #error Use Qt 4.7 or later version
 #endif


### PR DESCRIPTION
Just a compiler directive to include getopt.h when qt version > 4.8.  Fixes specrunner compile issues on newer qt versions:

specrunner.cpp: In function ‘int main(int, char*_)’:
specrunner.cpp:37:39: error: ‘getopt’ was not declared in this scope
specrunner.cpp:43:20: error: ‘optarg’ was not declared in this scope
specrunner.cpp:48:7: error: ‘optind’ was not declared in this scope
specrunner.cpp:61:16: error: ‘optind’ was not declared in this scope
make: *_\* [specrunner.o] Error 1

If you could merge it would be superfantastic.
