### PR TITLE
Won't run and compile with qt5.

### DIFF
--- a/ext/jasmine-webkit-specrunner/Page.cpp
+++ b/ext/jasmine-webkit-specrunner/Page.cpp
@@ -1,7 +1,4 @@
-#include <QtGui>
-#include <QtWebKit>
 #include <iostream>
-
 #include "Page.h"
 
 Page::Page() : QWebPage() {}

--- a/ext/jasmine-webkit-specrunner/Page.h
+++ b/ext/jasmine-webkit-specrunner/Page.h
@@ -2,7 +2,11 @@
 #define JHW_PAGE
 
 #include <QtGui>
-#include <QtWebKit>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+  #include <QtWebKitWidgets>
+#else
+  #include <QtWebKit>
+#endif
 
 class Page: public QWebPage {
   Q_OBJECT

--- a/ext/jasmine-webkit-specrunner/Runner.cpp
+++ b/ext/jasmine-webkit-specrunner/Runner.cpp
@@ -1,11 +1,3 @@
-#include <QtGui>
-#include <QtWebKit>
-#include <QFile>
-#include <QTextStream>
-#include <iostream>
-#include <sstream>
-#include <QQueue>
-
 #include "Runner.h"
 #include "Page.h"
 

--- a/ext/jasmine-webkit-specrunner/Runner.h
+++ b/ext/jasmine-webkit-specrunner/Runner.h
@@ -2,7 +2,11 @@
 #define JHW_RUNNER
 
 #include <QtGui>
-#include <QtWebKit>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+  #include <QtWebKitWidgets>
+#else
+  #include <QtWebKit>
+#endif
 #include <QFile>
 #include <QTextStream>
 #include <iostream>

--- a/ext/jasmine-webkit-specrunner/Runner.h
+++ b/ext/jasmine-webkit-specrunner/Runner.h
@@ -1,12 +1,6 @@
 #ifndef JHW_RUNNER
 #define JHW_RUNNER
 
-#include <QtGui>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-  #include <QtWebKitWidgets>
-#else
-  #include <QtWebKit>
-#endif
 #include <QFile>
 #include <QTextStream>
 #include <iostream>

--- a/ext/jasmine-webkit-specrunner/common.pri
+++ b/ext/jasmine-webkit-specrunner/common.pri
@@ -1,7 +1,12 @@
 TEMPLATE = app
 CONFIG -= app_bundle
 QMAKE_INFO_PLIST = Info.plist
-QT += network webkit
+QT += network
+greaterThan(QT_MAJOR_VERSION, 4) {
+  QT += webkitwidgets
+} else {
+  QT += webkit
+}
 
 SOURCES = Page.cpp Runner.cpp
 HEADERS = Page.h Runner.h


### PR DESCRIPTION
Won't run and compile with qt5. Error:

```
$ rake db:migrate
No runner found, attempting to compile...
make: *** Нет правила для сборки цели `clean'.  Останов.
which: no gmake in (/home/petrushka/.rvm/gems/ruby-1.9.3-p327/bin:/home/petrushka/.rvm/gems/ruby-1.9.3-p327@global/bin:/home/petrushka/.rvm/rubies/ruby-1.9.3-p327/bin:/home/petrushka/.rvm/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:/opt/android-ndk:/opt/android-sdk/platform-tools:/opt/android-sdk/tools:/opt/java/bin:/opt/java/db/bin:/opt/java/jre/bin:/usr/bin/vendor_perl:/usr/bin/core_perl:/opt/qt/bin)
g++ -c -pipe -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2 -Wall -W -D_REENTRANT -fPIE -DQT_NO_DEBUG -DQT_WEBKIT_LIB -DQT_NETWORK_LIB -DQT_GUI_LIB -DQT_CORE_LIB -I/usr/lib/qt/mkspecs/linux-g++ -I. -I/usr/include/qt5 -I/usr/include/qt5/QtWebKit -I/usr/include/qt5/QtNetwork -I/usr/include/qt5/QtGui -I/usr/include/qt5/QtCore -I. -o Page.o Page.cpp
In file included from Page.cpp:5:0:
Page.h:7:20: Error: invalid use of incomplete type «class QWebPage»
In file included from /usr/include/qt5/QtWebKit/QtWebKit:8:0,
                 from Page.cpp:2:
/usr/include/qt5/QtWebKit/qwebelement.h:157:18: Error: forward declaration of «class QWebPage»
Page.cpp: In constructor «Page::Page()»:
Page.cpp:7:16: Error: type «QWebPage» is not a direct base of «Page»
make: *** [Page.o] Error 1
```

I fixed it in my pull request.
