### PR TITLE
add ember-script support

### DIFF
--- a/bin/jasmine-headless-webkit
+++ b/bin/jasmine-headless-webkit
@@ -6,6 +6,7 @@ $: << File.expand_path('../../lib', __FILE__)
 
 require 'jasmine-headless-webkit'
 require 'coffee-script'
+require 'ember_script'
 
 Jasmine::Headless::CommandLine.run!
 

--- a/jasmine-headless-webkit.gemspec
+++ b/jasmine-headless-webkit.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'jasmine-core'
   s.add_runtime_dependency 'coffee-script'
+  s.add_runtime_dependency 'ember_script'
   s.add_runtime_dependency 'rainbow'
   s.add_runtime_dependency 'multi_json', '>= 1.2.0'
   s.add_runtime_dependency 'sprockets'

--- a/lib/autotest/jasmine_mixin.rb
+++ b/lib/autotest/jasmine_mixin.rb
@@ -1,7 +1,7 @@
 module JasmineMixin
   JASMINE_PROGRAM = File.expand_path('../../../bin/jasmine-headless-webkit', __FILE__)
 
-  JAVASCRIPT_EXTENSIONS = %w{js coffee}
+  JAVASCRIPT_EXTENSIONS = %w{js coffee em}
 
   def self.included(klass)
     klass::ALL_HOOKS << [ :run_jasmine, :ran_jasmine ]
@@ -92,7 +92,7 @@ module JasmineMixin
   end
 
   def setup_jasmine_project_mappings
-    add_mapping(%r{spec/javascripts/.*_spec\.(js|coffee)}) { |filename, _|
+    add_mapping(%r{spec/javascripts/.*_spec\.(js|coffee|em)}) { |filename, _|
       filename
     }
 
@@ -101,6 +101,10 @@ module JasmineMixin
     }
 
     add_mapping(%r{app/coffeescripts/(.*)\.coffee}) { |_, m|
+      files_matching(%r{spec/javascripts/#{m[1]}_spec\..*$})
+    }
+
+    add_mapping(%r{app/emberscripts/(.*)\.em}) { |_, m|
       files_matching(%r{spec/javascripts/#{m[1]}_spec\..*$})
     }
   end

--- a/lib/jasmine/headless.rb
+++ b/lib/jasmine/headless.rb
@@ -2,12 +2,13 @@ require 'pathname'
 
 module Jasmine
   module Headless
-    
+
     EXCLUDED_FORMATS = %w{less sass scss erb str}
-    
+
     autoload :CommandLine, 'jasmine/headless/command_line'
 
     autoload :CoffeeScriptCache, 'jasmine/headless/coffee_script_cache'
+    autoload :EmberScriptCache, 'jasmine/headless/ember_script_cache'
     autoload :SpecFileAnalyzer, 'jasmine/headless/spec_file_analyzer'
     autoload :CacheableAction, 'jasmine/headless/cacheable_action'
     autoload :VERSION, 'jasmine/headless/version'
@@ -19,10 +20,11 @@ module Jasmine
     autoload :UniqueAssetList, 'jasmine/headless/unique_asset_list'
 
     autoload :TemplateWriter, 'jasmine/headless/template_writer'
-    
+
     autoload :FileChecker, 'jasmine/headless/file_checker'
 
     autoload :CoffeeTemplate, 'jasmine/headless/coffee_template'
+    autoload :EmberScriptTemplate, 'jasmine/headless/ember_script_template'
     autoload :JSTemplate, 'jasmine/headless/js_template'
     autoload :JSTTemplate, 'jasmine/headless/jst_template'
     autoload :CSSTemplate, 'jasmine/headless/css_template'

--- a/lib/jasmine/headless/command_line.rb
+++ b/lib/jasmine/headless/command_line.rb
@@ -3,6 +3,7 @@ module Jasmine::Headless
     class << self
       def run!
         require 'coffee-script'
+        require 'ember_script'
         require 'rainbow'
 
         begin
@@ -18,6 +19,8 @@ module Jasmine::Headless
             exit runner.run
           end
         rescue CoffeeScript::CompilationError
+          exit 1
+        rescue ExecJS::ProgramError
           exit 1
         rescue StandardError => e
           $stderr.puts "[%s] %s (%s)" % [ "jasmine-headless-webkit".color(:red), e.message.color(:white), e.class.name.color(:yellow) ]

--- a/lib/jasmine/headless/ember_script_cache.rb
+++ b/lib/jasmine/headless/ember_script_cache.rb
@@ -1,0 +1,20 @@
+require 'ember_script'
+require 'digest/sha1'
+require 'fileutils'
+
+module Jasmine
+  module Headless
+    class EmberScriptCache < CacheableAction
+      class << self
+        def cache_type
+          "ember_script"
+        end
+      end
+
+      def action
+        EmberScript.compile(File.read(file))
+      end
+    end
+  end
+end
+

--- a/lib/jasmine/headless/ember_script_template.rb
+++ b/lib/jasmine/headless/ember_script_template.rb
@@ -1,0 +1,36 @@
+require 'tilt/template'
+require 'rainbow'
+
+module Jasmine::Headless
+  class EmberScriptTemplate < Tilt::Template
+    include Jasmine::Headless::FileChecker
+
+    self.default_mime_type = 'application/javascript'
+
+    def prepare ; end
+
+    def evaluate(scope, locals, &block)
+      if bad_format?(file)
+        alert_bad_format(file)
+        return ''
+      end
+      begin
+        cache = Jasmine::Headless::EmberScriptCache.new(file)
+        source = cache.handle
+        if cache.cached?
+          %{<script type="text/javascript" src="#{cache.cache_file}"></script>
+            <script type="text/javascript">window.CSTF['#{File.split(cache.cache_file).last}'] = '#{file}';</script>}
+        else
+          %{<script type="text/javascript">#{source}</script>}
+        end
+      rescue ExecJS::ProgramError => ne
+        puts "[%s] %s: %s" % [ 'emberscript'.color(:red), file.color(:yellow), "#{ne.message}".color(:white) ]
+        raise ne
+      rescue StandardError => e
+        puts "[%s] Error in compiling file: %s" % [ 'emberscript'.color(:red), file.color(:yellow) ]
+        raise e
+      end
+    end
+  end
+end
+

--- a/lib/jasmine/headless/files_list.rb
+++ b/lib/jasmine/headless/files_list.rb
@@ -150,6 +150,7 @@ module Jasmine::Headless
         end
 
         register_engine '.coffee', Jasmine::Headless::CoffeeTemplate
+        register_engine '.em', Jasmine::Headless::EmberScriptTemplate
         register_engine '.js', Jasmine::Headless::JSTemplate
         register_engine '.css', Jasmine::Headless::CSSTemplate
         register_engine '.jst', Jasmine::Headless::JSTTemplate

--- a/lib/jasmine/headless/runner.rb
+++ b/lib/jasmine/headless/runner.rb
@@ -1,6 +1,7 @@
 require 'fileutils'
 
 require 'coffee-script'
+require 'ember_script'
 require 'rainbow'
 
 require 'yaml'


### PR DESCRIPTION
As titled. Ref: [emberscript](http://emberscript.com/)

I have come across a project where I am heavily developing in [ember.js](http://emberjs.com/), and I adopted emberscript for the library.

I'd like to use emberscript in `jasmine-headless-webkit` too, but it seems that the supported Sprockets engines are hard-coded. I tried adding to it only in userland code, but it ended up being a large hack, cross-referencing and monkey-patching `jasmine-headless-webkit` itself all over the place.

This PR adds emberscript support by hardcoding it into the library, just like how coffeescript is done. Not sure if I have done it The Right Way though, basically I just copied everything that is coffeescript-related, and made an emberscript version for it.

If it could be refactored to include only the needed extensions on-demand and allow userland injections of new Sprockets engines, then it would be perfect - but I don't know how to do it. As for the added heavyweight for a niche audience, well, IMHO `jst` templates do not appear that often either. So I'd say the inclusion of emberscript is likewise justifiable simply as a harmless bonus feature like the `jst` case.
