### PR TITLE
remove .coffee extension on compiled version of CoffeeScript files

### DIFF
--- a/lib/jasmine/headless/coffee_script_cache.rb
+++ b/lib/jasmine/headless/coffee_script_cache.rb
@@ -14,6 +14,11 @@ module Jasmine
       def action
         CoffeeScript.compile(File.read(file))
       end
+
+      def relative_cache_file
+        super.gsub(/.coffee$/, '')
+      end
+
     end
   end
 end


### PR DESCRIPTION
When compiled, CoffeeScript files had names like "my_lib.coffee.js". This
broke compatibility with RequireJS.  Changing the naming convention to use
only the .js extension allows files to be used as RequireJS modules.
